### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/griff182uk0203/61bfa296-449c-443e-8d74-7826bcc57a22/8c2c04f3-2fa9-49ff-9076-caef88bfaff7/_apis/work/boardbadge/34d39be6-9d77-4f8d-836c-26588ebe786d)](https://dev.azure.com/griff182uk0203/61bfa296-449c-443e-8d74-7826bcc57a22/_boards/board/t/8c2c04f3-2fa9-49ff-9076-caef88bfaff7/Custom.45c0008a-112f-41f0-bdde-d4edcadf4813)
 # What is `.trunk`?
 
 Trunk Check uses `.trunk` to find issues in your repositories and pull requests. Learn more


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#309](https://dev.azure.com/griff182uk0203/61bfa296-449c-443e-8d74-7826bcc57a22/_workitems/edit/309). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.